### PR TITLE
Inject context to nostr event handlers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ PORT=3000
 
 # Nostr settings
 NOSTR_PRIVATE_KEY="YOUR_NOSTR_PRIVATE_KEY"
+NOSTR_PUBLIC_KEY="The public key associated to the private key"
 NOSTR_RELAYS= "wss://relay.damus.io,wss://relay.hodl.ar,wss://nostr.wine,wss://offchain.pub,wss://nostr-pub.wellorder.net,wss://nos.lol"
 
 # Postgres settings

--- a/src/nostr/subscriptionName.ts
+++ b/src/nostr/subscriptionName.ts
@@ -2,12 +2,13 @@ import { Debugger } from 'debug';
 import type { NDKFilter, NostrEvent } from '@nostr-dev-kit/ndk';
 
 import { logger } from '../lib/utils';
+import { Context } from '@type/request';
 
 const log: Debugger = logger.extend('nostr:subscriptionName');
 
 const filter: NDKFilter = {
   // ids: null,
-  authors: ['46241efb55cbfc73d410a136fac1cf88ddb6778014b8a58cecd0df8b01a98ffc'],
+  authors: [''],
   kinds: [1],
   // '#e': null,
   // '#p': null,
@@ -17,9 +18,12 @@ const filter: NDKFilter = {
   // limit: null,
 };
 
-const handler = (event: NostrEvent) => {
-  log('******* Received event: *******');
-  log(event.content);
+const getHandler = (ctx: Context): ((event: NostrEvent) => void) => {
+  return (event: NostrEvent) => {
+    log('******* Received event: *******');
+    log(event.content);
+    ctx.outbox.publish(event);
+  };
 };
 
-export { filter, handler };
+export { filter, getHandler };

--- a/src/services/outbox/Outbox.ts
+++ b/src/services/outbox/Outbox.ts
@@ -1,17 +1,10 @@
-import NDK, {
-  NDKEvent,
-  NDKPrivateKeySigner,
-  NostrEvent,
-} from '@nostr-dev-kit/ndk';
+import NDK, { NDKEvent, NostrEvent } from '@nostr-dev-kit/ndk';
 
 export class OutboxService {
   private ndk: NDK;
 
-  constructor() {
-    this.ndk = new NDK({
-      explicitRelayUrls: process.env.NOSTR_RELAYS?.split(','),
-      signer: new NDKPrivateKeySigner(process.env.NOSTR_PRIVATE_KEY),
-    });
+  constructor(ndk: NDK) {
+    this.ndk = ndk;
   }
 
   publish(event: NostrEvent) {


### PR DESCRIPTION
In order to interact with the database and to publish events to nostr we now inject the context (which contains prisma and outbox service) to the handlers